### PR TITLE
Add Clippy to CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-version }}
-      
-      - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
       - uses: cargo-bins/cargo-binstall@main
 
       - name: Install cargo nextest
         run: cargo binstall cargo-nextest --secure --no-confirm --disable-telemetry
 
-      - run: cargo nextest run --workspace
+      - run: cargo nextest run --workspace --exclude examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
 name: ci
+
+env:
+  MSRV: 1.82
+
 on:
   pull_request:
   push:
@@ -6,13 +10,26 @@ on:
       - main
 
 jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: $MSRV
+          components: clippy
+      
+      - run: cargo clippy --all --tests --no-deps -- -D warnings
+      
   test:
     name: Test with Rust ${{matrix.rust-version}}
     runs-on: ubuntu-latest
+    needs: clippy
     strategy:
       matrix:
-        # 1.82 is our MSRV
-        rust-version: ["1.82", stable]
+        rust-version: [$MSRV, stable]
     steps:
       - uses: actions/checkout@v5
 
@@ -25,4 +42,4 @@ jobs:
       - name: Install cargo nextest
         run: cargo binstall cargo-nextest --secure --no-confirm --disable-telemetry
 
-      - run: cargo nextest run --workspace --exclude examples 
+      - run: cargo nextest run --workspace --exclude examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: ci
 
-env:
-  MSRV: 1.82
-
 on:
   pull_request:
   push:
@@ -18,7 +15,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: $MSRV
+          toolchain: 1.82
           components: clippy
       
       - name: Install Dependencies
@@ -32,7 +29,7 @@ jobs:
     needs: clippy
     strategy:
       matrix:
-        rust-version: [$MSRV, stable]
+        rust-version: [1.82, stable]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           toolchain: $MSRV
           components: clippy
       
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
       - run: cargo clippy --all-targets --no-deps -- -D warnings
       
   test:
@@ -36,10 +39,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust-version }}
+      
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
       - uses: cargo-bins/cargo-binstall@main
 
       - name: Install cargo nextest
         run: cargo binstall cargo-nextest --secure --no-confirm --disable-telemetry
 
-      - run: cargo nextest run --workspace --exclude examples
+      - run: cargo nextest run --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           toolchain: $MSRV
           components: clippy
       
-      - run: cargo clippy --all --tests --no-deps -- -D warnings
+      - run: cargo clippy --all-targets --no-deps -- -D warnings
       
   test:
     name: Test with Rust ${{matrix.rust-version}}

--- a/examples/service_client.rs
+++ b/examples/service_client.rs
@@ -16,7 +16,7 @@ fn get_number_from_stdin() -> Result<i64, io::Error> {
     loop {
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
-        
+
         match input.trim().parse::<i64>() {
             Ok(number) => return Ok(number),
             Err(e) => {
@@ -35,15 +35,12 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     info!("Please enter the first number that you'd like to sum:");
-    let first_number = tokio::task::spawn_blocking(|| get_number_from_stdin()).await??;
+    let first_number = tokio::task::spawn_blocking(get_number_from_stdin).await??;
 
     info!("Please enter the second number that you'd like to sum:");
-    let second_number = tokio::task::spawn_blocking(|| get_number_from_stdin()).await??;
+    let second_number = tokio::task::spawn_blocking(get_number_from_stdin).await??;
 
-    let node = NodeBuilder::new()
-        .name("/service_client")
-        .build()
-        .await?;
+    let node = NodeBuilder::new().name("/service_client").build().await?;
 
     let client = node
         .service_client::<TwoInts>("/add_two_ints", false)

--- a/examples/turtle_teleop.rs
+++ b/examples/turtle_teleop.rs
@@ -144,7 +144,7 @@ async fn main() -> anyhow::Result<()> {
     let mut gilrs = Gilrs::new().map_err(|e| anyhow!("Failed to set up gamepad handler: {e}"))?;
 
     // For the sake of simplicity we use the first gamepad reported by gilrs.
-    let (gamepad_id, gamepad) = match gilrs.gamepads().into_iter().next() {
+    let (gamepad_id, gamepad) = match gilrs.gamepads().next() {
         Some(gamepad) => gamepad,
         None => bail!("No gamepads were detected!"),
     };
@@ -206,12 +206,12 @@ async fn main() -> anyhow::Result<()> {
                         EventType::AxisChanged(axis, value, _) => match axis {
                             Axis::LeftStickY => {
                                 velocity_updated = true;
-                                state.ly = value.abs().gt(&DEADZONE).then(|| value).unwrap_or(0.0);
+                                state.ly = if value.abs().gt(&DEADZONE) { value } else { 0.0 };
                             },
 
                             Axis::RightStickX => {
                                 velocity_updated = true;
-                                state.rx = value.abs().gt(&DEADZONE).then(|| -value).unwrap_or(0.0);
+                                state.rx = if value.abs().gt(&DEADZONE) { -value } else { 0.0 };
                             },
 
                             _ => { },

--- a/rosrust-async-test/tests/clock.rs
+++ b/rosrust-async-test/tests/clock.rs
@@ -79,7 +79,7 @@ pub async fn multi_sleep() {
 
         let completed_duration = tokio::time::timeout(Duration::from_secs(1), done_rx.recv())
             .await
-            .expect("Timed out waiting for sleep task to complete")
+            .unwrap_or_else(|_| panic!("Timed out waiting for sleep task {duration} to complete"))
             .expect("Task completion channel closed");
 
         // There should not be any additional completion messages in the channel

--- a/rosrust-async-test/tests/clock.rs
+++ b/rosrust-async-test/tests/clock.rs
@@ -14,7 +14,7 @@ pub async fn sleep_and_wake() {
     let (node, _guard) = setup().await;
 
     let clock_publisher = node
-        .publish::<ClockMsg>("/clock", 1, false, false)
+        .publish::<ClockMsg>("/clock", 1, false, true)
         .await
         .unwrap();
 

--- a/rosrust-async-test/tests/clock.rs
+++ b/rosrust-async-test/tests/clock.rs
@@ -14,7 +14,7 @@ pub async fn sleep_and_wake() {
     let (node, _guard) = setup().await;
 
     let clock_publisher = node
-        .publish::<ClockMsg>("/clock", 1, false, true)
+        .publish::<ClockMsg>("/clock", 1, true, false)
         .await
         .unwrap();
 

--- a/rosrust-async-test/tests/node_shutdown.rs
+++ b/rosrust-async-test/tests/node_shutdown.rs
@@ -11,7 +11,7 @@ use util::{
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 pub async fn node_handles_api_shutdown() {
     let (node, _guard) = setup().await;
-    let slave_api = RosSlaveClient::new(&node.url(), "/integration_test");
+    let slave_api = RosSlaveClient::new(node.url(), "/integration_test");
 
     slave_api
         .shutdown("Shutdown request from slave API")

--- a/rosrust-async-test/tests/pubsub.rs
+++ b/rosrust-async-test/tests/pubsub.rs
@@ -142,10 +142,12 @@ pub async fn publish_to_multiple_subscribers() {
         }),
     )
     .await
-    .expect(&format!(
-        "Timed out waiting for subscribers to check in, {} of {} completed",
-        rx_message_count.load(Ordering::Acquire),
-        NUM_SUBSCRIBERS
-    ))
+    .unwrap_or_else(|_| {
+        panic!(
+            "Timed out waiting for subscribers to check in, {} of {} completed",
+            rx_message_count.load(Ordering::Acquire),
+            NUM_SUBSCRIBERS
+        )
+    })
     .unwrap();
 }

--- a/rosrust-async-test/tests/util/mod.rs
+++ b/rosrust-async-test/tests/util/mod.rs
@@ -114,9 +114,7 @@ pub async fn wait_for_subscriber_connections(
         }),
     )
     .await
-    .expect(&format!(
-        "Timed out waiting for {subscriber_count} subscriber(s) to connect"
-    ))
+    .unwrap_or_else(|_| panic!("Timed out waiting for {subscriber_count} subscriber(s) to connect"))
     .unwrap();
 }
 
@@ -142,9 +140,7 @@ pub async fn wait_for_publisher_connections(
         }),
     )
     .await
-    .expect(&format!(
-        "Timed out waiting for {publisher_count} publisher(s) to connect"
-    ))
+    .unwrap_or_else(|_| panic!("Timed out waiting for {publisher_count} publisher(s) to connect"))
     .unwrap();
 }
 

--- a/rosrust-async/src/tcpros/header/de.rs
+++ b/rosrust-async/src/tcpros/header/de.rs
@@ -318,6 +318,6 @@ mod tests {
         assert_eq!(header.msg_type, "std_msgs/String");
         assert_eq!(header.msg_definition, "string data\n\n");
         assert_eq!(header.md5sum, "992ce8a1687cec8c8bd883ec73ca41d1");
-        assert_eq!(header.latching, true);
+        assert!(header.latching);
     }
 }


### PR DESCRIPTION
This PR adds a new Clippy job to the GitHub workflow to ensure PRs are properly linted.
Additionally, various warnings across `rosrust-async-test` and `examples` have been corrected.
