### PR TITLE
Use more appropriate collections across crate

### DIFF
--- a/rosrust-async/src/node/actors/publisher.rs
+++ b/rosrust-async/src/node/actors/publisher.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, BTreeSet, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     io,
     marker::PhantomData,
     net::{IpAddr, SocketAddr},
@@ -33,7 +33,7 @@ pub enum PublisherActorMsg {
     },
     GetConnectedSubscriberIDs {
         topic_name: String,
-        reply: RpcReplyPort<Option<BTreeSet<String>>>,
+        reply: RpcReplyPort<Option<HashSet<String>>>,
     },
     RegisterPublisher {
         topic: Topic,
@@ -218,7 +218,7 @@ impl PublisherActor {
     pub async fn get_connected_subscriber_ids(
         state: &mut PublisherActorState,
         topic_name: String,
-    ) -> Option<BTreeSet<String>> {
+    ) -> Option<HashSet<String>> {
         trace!("GetConnectedSubscriberIDs called");
 
         let (_, publication) = state.publications.get(&topic_name)?;

--- a/rosrust-async/src/node/actors/subscriber.rs
+++ b/rosrust-async/src/node/actors/subscriber.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, BTreeSet, HashMap, VecDeque},
+    collections::{hash_map::Entry, HashMap, HashSet, VecDeque},
     io,
     marker::PhantomData,
     sync::{
@@ -45,7 +45,7 @@ pub enum SubscriberActorMsg {
     },
     GetConnectedPublisherUrls {
         topic_name: String,
-        reply: RpcReplyPort<Option<BTreeSet<String>>>,
+        reply: RpcReplyPort<Option<HashSet<String>>>,
     },
     RegisterSubscriber {
         topic: Topic,
@@ -63,7 +63,7 @@ pub enum SubscriberActorMsg {
     },
     UpdateConnectedPublishers {
         topic_name: String,
-        publishers: BTreeSet<String>,
+        publishers: HashSet<String>,
     },
 }
 
@@ -205,7 +205,7 @@ impl SubscriberActor {
     pub async fn get_connected_publisher_urls(
         state: &mut SubscriberActorState,
         topic_name: String,
-    ) -> Option<BTreeSet<String>> {
+    ) -> Option<HashSet<String>> {
         trace!("GetConnectedPublisherUrls called");
 
         let (_, subscription) = state.subscriptions.get(&topic_name)?;
@@ -266,7 +266,7 @@ impl SubscriberActor {
                 let latched_msgs = subscription.latched_msgs().await;
 
                 return Ok(Subscriber::with_latched(
-                    latched_msgs.into_iter().collect(),
+                    latched_msgs.into(),
                     subscription.data_receiver(),
                     guard,
                 ));
@@ -331,7 +331,7 @@ impl SubscriberActor {
     pub async fn update_connected_publishers(
         state: &mut SubscriberActorState,
         topic_name: String,
-        publisher_addrs: BTreeSet<String>,
+        publisher_addrs: HashSet<String>,
     ) {
         trace!("UpdateConnectedPublishers called");
 

--- a/rosrust-async/src/node/api/router.rs
+++ b/rosrust-async/src/node/api/router.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, process, sync::Arc};
+use std::{collections::HashSet, process, sync::Arc};
 
 use async_shutdown::ShutdownManager;
 use async_trait::async_trait;
@@ -245,7 +245,7 @@ impl Handler for PublisherUpdateHandler {
             self.sub_actor,
             SubscriberActorMsg::UpdateConnectedPublishers {
                 topic_name,
-                publishers: BTreeSet::from_iter(publishers),
+                publishers: HashSet::from_iter(publishers),
             }
         )
         .map_err(|e| {

--- a/rosrust-async/src/node/mod.rs
+++ b/rosrust-async/src/node/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{HashMap, HashSet},
     future::Future,
     net::SocketAddr,
     sync::Arc,
@@ -349,7 +349,7 @@ impl Node {
     pub async fn get_connected_subscriber_ids(
         &self,
         topic_name: impl Into<String>,
-    ) -> NodeResult<Option<BTreeSet<String>>> {
+    ) -> NodeResult<Option<HashSet<String>>> {
         Ok(call!(self.state.pub_actor, |reply| {
             PublisherActorMsg::GetConnectedSubscriberIDs {
                 topic_name: topic_name.into(),
@@ -470,7 +470,7 @@ impl Node {
     pub async fn get_connected_publisher_urls(
         &self,
         topic_name: impl Into<String>,
-    ) -> NodeResult<Option<BTreeSet<String>>> {
+    ) -> NodeResult<Option<HashSet<String>>> {
         Ok(call!(self.state.sub_actor, |reply| {
             SubscriberActorMsg::GetConnectedPublisherUrls {
                 topic_name: topic_name.into(),

--- a/rosrust-async/src/tcpros/publication.rs
+++ b/rosrust-async/src/tcpros/publication.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, io, net::SocketAddr, sync::Arc};
+use std::{collections::HashSet, io, net::SocketAddr, sync::Arc};
 
 use bytes::Bytes;
 use tokio::{
@@ -30,7 +30,7 @@ pub enum PublicationError {
 pub struct Publication {
     topic: Topic,
     address: SocketAddr,
-    subscriber_ids: Arc<RwLock<BTreeSet<String>>>,
+    subscriber_ids: Arc<RwLock<HashSet<String>>>,
     data_tx: broadcast::Sender<Bytes>,
     _drop_guard: DropGuard,
 }
@@ -58,7 +58,7 @@ impl Publication {
 
         let header_bytes = header::to_bytes(&header)?;
 
-        let subscriber_ids = Arc::new(RwLock::new(BTreeSet::<String>::new()));
+        let subscriber_ids = Arc::new(RwLock::new(HashSet::<String>::new()));
         let (data_tx, data_rx) = broadcast::channel::<Bytes>(queue_size);
         let cancel_token = CancellationToken::new();
 
@@ -118,7 +118,7 @@ impl Publication {
         self.data_tx.clone()
     }
 
-    pub async fn subscriber_ids(&self) -> BTreeSet<String> {
+    pub async fn subscriber_ids(&self) -> HashSet<String> {
         self.subscriber_ids.read().await.clone()
     }
 
@@ -130,7 +130,7 @@ impl Publication {
         header: PublisherHeader,
         header_bytes: &[u8],
         tcp_nodelay: bool,
-        subscriber_ids: Arc<RwLock<BTreeSet<String>>>,
+        subscriber_ids: Arc<RwLock<HashSet<String>>>,
         mut data_rx: broadcast::Receiver<Bytes>,
         tcp_listener: TcpListener,
         cancel_token: CancellationToken,

--- a/rosrust-async/src/tcpros/subscription.rs
+++ b/rosrust-async/src/tcpros/subscription.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{HashMap, HashSet},
     io,
     sync::Arc,
 };
@@ -33,8 +33,8 @@ pub struct Subscription {
     topic: Topic,
     header: SubscriberHeader,
     header_bytes: Vec<u8>,
-    publisher_addrs: Arc<RwLock<BTreeSet<String>>>,
-    latched_msgs: Arc<RwLock<BTreeMap<String, Bytes>>>,
+    publisher_addrs: Arc<RwLock<HashSet<String>>>,
+    latched_msgs: Arc<RwLock<HashMap<String, Bytes>>>,
     data_tx: broadcast::Sender<Bytes>,
     cancel_token: CancellationToken,
     _data_rx: broadcast::Receiver<Bytes>,
@@ -85,11 +85,11 @@ impl Subscription {
         self.data_tx.subscribe()
     }
 
-    pub async fn latched_msgs(&self) -> BTreeSet<Bytes> {
+    pub async fn latched_msgs(&self) -> Vec<Bytes> {
         self.latched_msgs.read().await.values().cloned().collect()
     }
 
-    pub async fn publisher_addrs(&self) -> BTreeSet<String> {
+    pub async fn publisher_addrs(&self) -> HashSet<String> {
         self.publisher_addrs.read().await.clone()
     }
 
@@ -176,7 +176,7 @@ impl Subscription {
 
     async fn subscriber_task(
         publisher_header: PublisherHeader,
-        latched_msgs: Arc<RwLock<BTreeMap<String, Bytes>>>,
+        latched_msgs: Arc<RwLock<HashMap<String, Bytes>>>,
         data_tx: broadcast::Sender<Bytes>,
         mut publisher_stream: TcpStream,
         cancel_token: CancellationToken,


### PR DESCRIPTION
This PR cleans up the vestigial usage of BTreeMap/BTreeSet, opting for more suitable collections since ordering is unnecessary. 

This also resolves a bug where `Subscription::latched_msgs` would discard duplicate messages erroneously.